### PR TITLE
Error without ms on timoute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       REGISTRY_NOTIFICATIONS_ENDPOINTS: >
         - name: portus
           url: http://portus:3000/v2/webhooks/events
-          timeout: 5000
+          timeout: 5000ms
           threshold: 2
           backoff: 20s
 


### PR DESCRIPTION
# ADD MS TO TimeOut REGISTRY INTERPRETE pico second and made error and bug the whole portus...2.3 works great, see https://github.com/SUSE/Portus/issues/905 and https://github.com/SUSE/Portus/pull/1068