### PR TITLE
Remove 443 has in doc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,8 @@ services:
       REGISTRY_LOG_LEVEL: warn
       REGISTRY_STORAGE_DELETE_ENABLED: 'true'
       REGISTRY_AUTH: token
-      REGISTRY_AUTH_TOKEN_REALM: https://portus.dev:443/v2/token
-      REGISTRY_AUTH_TOKEN_SERVICE: registry.dev:443
+      REGISTRY_AUTH_TOKEN_REALM: https://portus.dev/v2/token
+      REGISTRY_AUTH_TOKEN_SERVICE: registry.dev
       REGISTRY_AUTH_TOKEN_ISSUER: portus.dev
       REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: /certs/fullchain.pem
       REGISTRY_HTTP_SECRET: somethingother


### PR DESCRIPTION
Depends if HTTPS or not enable but the detection not works with SSL, we have to create our registry directly and skip check (With FQDN:5000 the server is detected but it's on the host is self not a fully HTTPS check.). 

So go on the UI, and use SSL by checkbox and the name MUST BE THE SAME HAS THE HOSTNAME OF REGISTRY CONF so don't add any port, and skip change or change it after.

Look docker registry section.

http://port.us.org/docs/setups/4_portus_and_registry_on_the_same_fqdn.html