### PR TITLE
x.minutes is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM library/ruby:2.3.1
 MAINTAINER Eugen Mayer <eugen.mayer@kontextwork.de>
-ENV CATALOG_CRON="5.minutes"
+ENV CATALOG_CRON="5"
 ENV COMPOSE=1
 EXPOSE 3000
 


### PR DESCRIPTION
see log file : [deprecated] The 'x.minutes' format is deprecated for configuration values such as `jwt_expiration_time`. From now on these values are expected to be integers representing minutes.

https://github.com/SUSE/Portus/commit/53400181e439